### PR TITLE
Feature: Member 기본 CRUD API 개발 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/architrave/portfolio/api/service/MemberService.java
+++ b/src/main/java/com/architrave/portfolio/api/service/MemberService.java
@@ -1,0 +1,43 @@
+package com.architrave.portfolio.api.service;
+
+import com.architrave.portfolio.domain.model.Member;
+import com.architrave.portfolio.domain.repository.MemberRepository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member createMember(Member member){
+        if(memberRepository.existsByEmail(member.getEmail())){
+            throw new IllegalArgumentException("already exist email");
+        }
+        return memberRepository.save(member);
+    }
+
+    @Transactional
+    public void removeMember(Member member) {
+        if(!memberRepository.existsByEmail(member.getEmail())){
+            throw new NoSuchElementException("there is no member");
+        }
+        memberRepository.delete(member);
+    }
+
+    @Transactional(readOnly = true)
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElse(null);
+    }
+    @Transactional(readOnly = true)
+    public Member findMemberById(Member member) {
+        return memberRepository.findById(member.getId())
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/architrave/portfolio/api/service/MemberService.java
+++ b/src/main/java/com/architrave/portfolio/api/service/MemberService.java
@@ -40,4 +40,10 @@ public class MemberService {
         return memberRepository.findById(member.getId())
                 .orElse(null);
     }
+
+    @Transactional(readOnly = true)
+    public Member findMemberByAui(String aui) {
+        return memberRepository.findByAui(aui)
+                .orElse(null);
+    }
 }

--- a/src/main/java/com/architrave/portfolio/domain/model/Member.java
+++ b/src/main/java/com/architrave/portfolio/domain/model/Member.java
@@ -2,6 +2,7 @@ package com.architrave.portfolio.domain.model;
 
 import com.architrave.portfolio.domain.model.enumType.RoleType;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,12 +19,20 @@ public class Member extends BaseEntity{
     @Column(name = "member_id")
     private Long id;
 
+    @Column(unique = true)
+    @NotNull
     private String email;
+
+    @NotNull
     private String password;
+    @Column(unique = true)
+    @NotNull
     private String aui;
 
     @Enumerated
+    @NotNull
     private RoleType role;
+
     private String description;
 
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/com/architrave/portfolio/domain/model/Member.java
+++ b/src/main/java/com/architrave/portfolio/domain/model/Member.java
@@ -4,15 +4,14 @@ import com.architrave.portfolio.domain.model.enumType.RoleType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Entity
-@Builder
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class Member extends BaseEntity{
 
     @Id @GeneratedValue
@@ -25,6 +24,9 @@ public class Member extends BaseEntity{
 
     @NotNull
     private String password;
+
+    @NotNull
+    private String username;    //활동명 (중복가능)
     @Column(unique = true)
     @NotNull
     private String aui;
@@ -37,7 +39,42 @@ public class Member extends BaseEntity{
 
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "landing_box_id")
-    private LandingBox loadingBox;
+    private LandingBox landingBox;
 
+    private String generateAui(String username){
+        String uuid_8 = UUID.randomUUID().toString().substring(0,8);
+        return username + "-" + uuid_8;
+    }
 
+    public void setUsername(String username) {
+        this.username = username;
+        this.aui = generateAui(username);
+    }
+
+    public void setRole(RoleType role) {
+        this.role = role;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public static Member createMember(
+            String email,
+            String password,
+            String username,
+            RoleType role,
+            String description,
+            LandingBox landingBox
+    ){
+        Member member = new Member();
+        member.email = email;
+        member.password = password;
+        member.username = username;
+        member.aui = member.generateAui(username);
+        member.role = role;
+        member.description = description;
+        member.landingBox = landingBox;
+        return member;
+    }
 }

--- a/src/main/java/com/architrave/portfolio/domain/model/builder/MemberBuilder.java
+++ b/src/main/java/com/architrave/portfolio/domain/model/builder/MemberBuilder.java
@@ -1,0 +1,61 @@
+package com.architrave.portfolio.domain.model.builder;
+
+import com.architrave.portfolio.domain.model.LandingBox;
+import com.architrave.portfolio.domain.model.Member;
+import com.architrave.portfolio.domain.model.enumType.RoleType;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class MemberBuilder {
+    private String email;
+    private String password;
+    private String username;
+    private RoleType role;
+    private String description;
+    private LandingBox loadingBox;
+
+    public MemberBuilder email(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public MemberBuilder password(String password) {
+        this.password = password;
+        return this;
+    }
+    public MemberBuilder username(String username) {
+        this.username = username;
+        return this;
+    }
+    public MemberBuilder role(RoleType role) {
+        this.role = role;
+        return this;
+    }
+
+    public MemberBuilder description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public MemberBuilder loadingBox(LandingBox loadingBox) {
+        this.loadingBox = loadingBox;
+        return this;
+    }
+    public Member build() {
+        validateMember();
+        return Member.createMember(
+                this.email,
+                this.password,
+                this.username,
+                this.role,
+                this.description,
+                this.loadingBox
+        );
+    }
+    private void validateMember(){
+        if(email == null || password == null || username == null || role == null){
+            throw new IllegalArgumentException("required value is empty");
+        }
+    }
+
+}

--- a/src/main/java/com/architrave/portfolio/domain/repository/MemberRepository/MemberRepository.java
+++ b/src/main/java/com/architrave/portfolio/domain/repository/MemberRepository/MemberRepository.java
@@ -8,4 +8,7 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Boolean existsByEmail(String email);
+
+    Optional<Member> findByAui(String aui);
+
 }

--- a/src/main/java/com/architrave/portfolio/domain/repository/MemberRepository/MemberRepository.java
+++ b/src/main/java/com/architrave/portfolio/domain/repository/MemberRepository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.architrave.portfolio.domain.repository.MemberRepository;
+
+import com.architrave.portfolio.domain.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Boolean existsByEmail(String email);
+}

--- a/src/test/java/com/architrave/portfolio/MemberTest.java
+++ b/src/test/java/com/architrave/portfolio/MemberTest.java
@@ -1,0 +1,70 @@
+package com.architrave.portfolio;
+
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class MemberTest {
+
+    private MemberService memberService;
+
+    @Autowired
+    public MemberTest(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @Test
+    public void createTest(){
+        //given
+        //when
+        //then
+    }
+    @Test
+    public void createDuplicateTest(){
+        //given
+        //when
+        //then
+    }
+    @Test
+    public void removeTest(){
+        //given
+        //when
+        //then
+    }
+    @Test
+    public void removeEmptyTest(){
+        //given
+        //when
+        //then
+    }
+    @Test
+    public void findWithIdTest(){
+        //given
+        //when
+        //then
+    }
+    @Test
+    public void findWithAUITest(){
+        //given
+        //when
+        //then
+    }
+    @Test
+    public void findDuplicateTest(){
+        //given
+        //when
+        //then
+    }
+    @Test
+    public void findEmptyTest(){
+        //given
+        //when
+        //then
+    }
+
+
+}

--- a/src/test/java/com/architrave/portfolio/MemberTest.java
+++ b/src/test/java/com/architrave/portfolio/MemberTest.java
@@ -1,70 +1,284 @@
 package com.architrave.portfolio;
 
 
+import com.architrave.portfolio.api.service.MemberService;
+import com.architrave.portfolio.domain.model.Member;
+import com.architrave.portfolio.domain.model.builder.MemberBuilder;
+import com.architrave.portfolio.domain.model.enumType.RoleType;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
+
 @SpringBootTest
-@Transactional
 public class MemberTest {
 
-    private MemberService memberService;
+    private final MemberService memberService;
+    private final EntityManager em;
+
+    private final String TEST_MEMBER_EMAIL = "lee@gmail.com";
+    private final String TEST_MEMBER_EMAIL_2 = "jung@gmail.com";
+    private final String TEST_MEMBER_PASSWORD = "12345";
+    private final String TEST_MEMBER_USERNAME = "이중섭";
+    private final String TEST_MEMBER_USERNAME_CHANGED = "중섭이";
+    private final RoleType ROLE_USER = RoleType.USER;
+    private final RoleType ROLE_CHANGED = RoleType.ADMIN;
 
     @Autowired
-    public MemberTest(MemberService memberService) {
+    public MemberTest(MemberService memberService, EntityManager em) {
         this.memberService = memberService;
+        this.em = em;
     }
 
     @Test
+    @Transactional
     public void createTest(){
         //given
+        Member member = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME)
+                .role(ROLE_USER)
+                .build();
+
         //when
+        Member afterCreateMember = memberService.createMember(member);
+        em.flush();
+        em.clear();
+
         //then
+        Assertions.assertNotNull(afterCreateMember.getId());
+        Assertions.assertEquals(afterCreateMember.getUsername(), TEST_MEMBER_USERNAME);
+        Assertions.assertNotNull(afterCreateMember.getAui());
     }
     @Test
-    public void createDuplicateTest(){
+    @Transactional
+    public void IllegalArgumentExceptionWhenCreateDuplicatedEmail(){
         //given
-        //when
-        //then
+        Member member1 = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME)
+                .role(ROLE_USER)
+                .build();
+
+        Member member2 = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME)
+                .role(ROLE_USER)
+                .build();
+
+        //when then
+        Assertions.assertThrows(IllegalArgumentException.class,()->{
+            memberService.createMember(member1);
+            em.flush();
+            em.clear();
+            memberService.createMember(member2);
+        });
     }
     @Test
+    @Transactional
+    public void IllegalArgumentExceptionWhenCreateWithEmptyUsernameAndAUI(){
+        //when then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            //given
+            Member member = new MemberBuilder()
+                    .email(TEST_MEMBER_EMAIL)
+                    .password(TEST_MEMBER_PASSWORD)
+                    .role(ROLE_USER)
+                    .build();
+        });
+    }
+    @Test
+    @Transactional
     public void removeTest(){
         //given
+        Member member = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME)
+                .role(ROLE_USER)
+                .build();
+
+        Member afterCreateMember = memberService.createMember(member);
+        em.flush();
+        em.clear();
+
         //when
+        memberService.removeMember(afterCreateMember);
+        em.flush();
+        em.clear();
+
         //then
+        Assertions.assertNull(memberService.findMemberById(afterCreateMember));
     }
     @Test
-    public void removeEmptyTest(){
+    @Transactional
+    public void NoSuchElementExceptionWhenRemoveEmpty(){
         //given
-        //when
-        //then
+        Member member = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME)
+                .role(ROLE_USER)
+                .build();
+
+        //when then
+        Assertions.assertThrows(NoSuchElementException.class,
+                ()-> memberService.removeMember(member));
     }
     @Test
+    @Transactional
     public void findWithIdTest(){
         //given
+        Member member = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME)
+                .role(ROLE_USER)
+                .build();
+
+        Member afterCreateMember = memberService.createMember(member);
+        em.flush();
+        em.clear();
+
         //when
+        Member findMember = memberService.findMemberById(afterCreateMember.getId());
+
         //then
+        Assertions.assertEquals(afterCreateMember.getEmail(), findMember.getEmail());
+        Assertions.assertEquals(afterCreateMember.getPassword(), findMember.getPassword());
+        Assertions.assertEquals(afterCreateMember.getUsername(), findMember.getUsername());
+        Assertions.assertEquals(afterCreateMember.getAui(), findMember.getAui());
+        Assertions.assertEquals(afterCreateMember.getRole(), findMember.getRole());
     }
     @Test
+    @Transactional
     public void findWithAUITest(){
         //given
+        Member member = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME)
+                .role(ROLE_USER)
+                .build();
+
+        Member afterCreateMember = memberService.createMember(member);
+
+        em.flush();
+        em.clear();
         //when
+        Member findMember = memberService.findMemberByAui(afterCreateMember.getAui());
+
         //then
+        Assertions.assertEquals(afterCreateMember.getEmail(), findMember.getEmail());
+        Assertions.assertEquals(afterCreateMember.getPassword(), findMember.getPassword());
+        Assertions.assertEquals(afterCreateMember.getAui(), findMember.getAui());
+        Assertions.assertEquals(afterCreateMember.getRole(), findMember.getRole());
+        Assertions.assertEquals(afterCreateMember.getUsername(), findMember.getUsername());
+
     }
     @Test
     public void findDuplicateTest(){
-        //given
-        //when
-        //then
+        //같은 이메일의 member create가 막혀있기에 성립불가
     }
     @Test
+    @Transactional
     public void findEmptyTest(){
         //given
-        //when
-        //then
+        //when then
+        Assertions.assertNull(memberService.findMemberById(1L));
     }
 
+
+
+
+
+    @Test
+    @Transactional
+    public void updateRoleTest(){   //일반 update 테스트, 중복가능
+        //given
+        Member member = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME)
+                .role(ROLE_USER)
+                .build();
+        Member createdMember = memberService.createMember(member);
+
+        //when
+        createdMember.setRole(ROLE_CHANGED);
+        em.flush();
+        em.clear();
+
+        Member afterUpdateMember = memberService.findMemberById(createdMember.getId());
+
+        //then
+        Assertions.assertEquals(afterUpdateMember.getId(), createdMember.getId());
+        Assertions.assertEquals(afterUpdateMember.getAui(), createdMember.getAui());
+        Assertions.assertEquals(afterUpdateMember.getRole(), ROLE_CHANGED);
+    }
+    @Test
+    @Transactional
+    public void updateUsernameTest(){   //중복가능, aui는 중복 불가
+        //given
+        Member member = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME)
+                .role(ROLE_USER)
+                .build();
+        Member createdMember = memberService.createMember(member);
+
+        //when
+        createdMember.setUsername(TEST_MEMBER_USERNAME_CHANGED);
+        em.flush();
+        em.clear();
+
+        //then
+        Assertions.assertEquals(createdMember.getId(), createdMember.getId());
+        Assertions.assertEquals(createdMember.getUsername(), TEST_MEMBER_USERNAME_CHANGED);
+        System.out.println(createdMember.getAui());
+    }
+    @Test
+    @Transactional
+    public void updateDuplicateUsernameTest(){   //중복가능, aui는 중복 불가
+        //given
+        Member member1 = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME)
+                .role(ROLE_USER)
+                .build();
+
+        Member member2 = new MemberBuilder()
+                .email(TEST_MEMBER_EMAIL_2)
+                .password(TEST_MEMBER_PASSWORD)
+                .username(TEST_MEMBER_USERNAME_CHANGED)
+                .role(ROLE_USER)
+                .build();
+        memberService.createMember(member1);
+        Member createdMember2 = memberService.createMember(member2);
+        em.flush();
+        em.clear();
+
+        //when
+        Member findMember = memberService.findMemberById(createdMember2.getId());
+        findMember.setUsername(TEST_MEMBER_USERNAME);
+        em.flush();
+        em.clear();
+
+        //then
+        Assertions.assertNotEquals(findMember.getUsername(), createdMember2.getUsername());
+        Assertions.assertEquals(findMember.getUsername(), TEST_MEMBER_USERNAME);
+        Assertions.assertEquals(findMember.getId(), createdMember2.getId());
+        Assertions.assertNotNull(findMember.getAui());
+
+    }
 
 }


### PR DESCRIPTION
- [ ] Member  Entity에서 활동명을 나타내는 username이 누락되어있어서 추가했습니다.

- [ ] Member의 멤버 변수 중 null이면 안되는 값들에 @NotNull을 추가했습니다.

- [ ] username을 기반으로 만들어지는 AUI의 특성을 표현하기 위해 generateAui()를 생성했습니다.

- [ ] 개발자가 실수로 generateAui()로 AUI 생성을 잊는 경우를 대비하고자  Member에 static 생성 메소드를 추가하고 기본 @Builder를 없애고 custom Builder class인 MemberBuilder 를 생성했습니다. MemberBuilder에서 username을 설정하면 AUI가 자동 생성 및 설정됩니다. 

- [ ] MemberBuilder에서 validateMember() 메소드를 통해 필수값이 설정되지 않은채로 build()를 하면 IllegalArgumentException을 던집니다.

- [ ] 생각할 수 있는 대부분의 상황에 대한 테스트코드를 생성했습니다.